### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,32 +3,13 @@ on:
   push:
     branches: [main]
 jobs:
-  deploy-widgets:
-    runs-on: ubuntu-latest
-    name: Deploy widgets to social.near (mainnet)
-    env:
-      BOS_DEPLOY_ACCOUNT_ID: ${{ vars.DEPLOY_ACCOUNT_ID }}
-      BOS_SIGNER_ACCOUNT_ID: ${{ vars.SIGNER_ACCOUNT_ID }}
-      BOS_SIGNER_PUBLIC_KEY: ${{ vars.SIGNER_PUBLIC_KEY }}
-      BOS_SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Install near-social CLI
-        run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v0.3.1/bos-cli-v0.3.1-installer.sh | sh
-
-      - name: Install bos-workspace from dev branch
-        run: |
-          npm install git+https://github.com/NEARBuilders/bos-workspace#main
-    
-      - name: Build the workspaces
-        run: |
-          npm run build
-
-      - name: Deploy widgets
-        working-directory: ./build/hyperfiles
-        run: |
-          bos components deploy "$BOS_DEPLOY_ACCOUNT_ID" sign-as "$BOS_SIGNER_ACCOUNT_ID" network-config mainnet sign-with-plaintext-private-key --signer-public-key "$BOS_SIGNER_PUBLIC_KEY" --signer-private-key "$BOS_SIGNER_PRIVATE_KEY" send
+  deploy-mainnet:
+    uses: NEARBuilders/bos-workspace/.github/workflows/deploy.yml@main
+    with:
+      deploy-env: "mainnet"
+      app-name: "discoverbos"
+      deploy-account-address:  hyperfiles.near
+      signer-account-address: hyperfiles.near
+      signer-public-key: ${{ vars.SIGNER_PUBLIC_KEY }}
+    secrets:
+      SIGNER_PRIVATE_KEY:  ${{ secrets.SIGNER_PRIVATE_KEY }}


### PR DESCRIPTION
We need to configure the private/public key.

Either use [near-cli-rs](https://github.com/near/near-cli-rs) or your wallet to get the private and public key for hyperfiles.near (Meteor Wallet has it in settings)

If using near-cli-rs, then it will be `near account import-account`, then sign in and save to key-chain or whatever you want.
Then, do: `near account add-key hyperfiles.near grant-full-access`

Or this may work too if you want to try a granular approach (might not work, haven't tried):
near account add-key hyperfiles.near grant-function-call-access --allowance '10 NEAR' --receiver-account-id social.near --method-names set`

But then this private and public key need to be configured in the Github Actions; from repo repo, go to "secrets and variables" → Actions